### PR TITLE
Fix spaces on setup.yml

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -77,10 +77,10 @@
       tags:
         - transmission
     - role: gimp
-     tags:
+      tags:
        - gimp
     - role: libreoffice
-     tags:
+      tags:
        - libreoffice
     - role: wallpapers
       tags:


### PR DESCRIPTION
Fixes this error

```
ERROR! Syntax Error while loading YAML.
  did not find expected '-' indicator
The error appears to be in 'setup.yml': line 80, column 6, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
    - role: gimp
     tags:
     ^ here
```